### PR TITLE
Fixed typo in the cli() function

### DIFF
--- a/happy/main.py
+++ b/happy/main.py
@@ -190,7 +190,7 @@ def cli() -> None:
             except TypeError:
                 # this triggers the command
                 # `happy get` without any other args
-                print("Please use an arguement after `get`\n")
+                print("Please use an argument after `get`\n")
                 get.print_help()  # print usage for `get`
             else:
                 if dt:


### PR DESCRIPTION
Typo Screenshot : 

![Screenshot from 2022-10-02 22-47-42](https://user-images.githubusercontent.com/92677342/193467459-f9d7b9ad-bb12-4757-ac0f-bdd6bb35f825.png)
