### PR TITLE
NEW: colored output and entry display formatting

### DIFF
--- a/happy/main.py
+++ b/happy/main.py
@@ -186,6 +186,8 @@ def display_entry(flowers, line, nocolor):
     global skip_flower  # the last flower used
     flower = ""
     flower_selection = ["🌼 ", "🍀 ", "🌻 ", "🌺 ", "🌹 ", "🌸 ", "🌷 ", "💐 ", "🏵️  "]
+
+    # format the output
     line = line.split(": ")
     date = line[0]
     entry = line[1]
@@ -193,7 +195,7 @@ def display_entry(flowers, line, nocolor):
     if nocolor:
         toggle_style = ["default", "default"]
 
-
+    # print line
     if line != "\n" and flowers:
         flower = choice(flower_selection)
         # randomly choose any flower except skip_flower to avoid repetition
@@ -284,7 +286,7 @@ def cli() -> None:
                     header("Random Entries")
                     read_file(
                         random=random_num, flowers=args.flowers, nocolor=args.nocolor
-                  )
+                    )
                 except ValueError:  # a valid number wasn't provided
                     console.print(
                         Markdown(

--- a/happy/main.py
+++ b/happy/main.py
@@ -55,13 +55,8 @@ def write_file(payload, time=None):
             console.print(f"Error occurred: {err}", style="error")
         else:
             console.print(
-                "",
-                Markdown(
-                    """Jar created!  
-Entry written successfully!  
-Use `happy get all` or `happy get today` to view your logs!  
-"""
-                ),
+                "\nJar created!\nEntry written successfully!\n",
+                Markdown("Use `happy get all` or `happy get today` to view your logs!"),
                 "",
                 style="info",
             )
@@ -79,11 +74,12 @@ def read_file(
     display = False
     if not exists(f"{HOME}/.happyjar.txt"):
         console.print(
+            "Error: your happyjar has not been initialised yet.",
             Markdown(
-                """Error: your happyjar has not been initialised yet.  
-To initialise your happyjar, log an entry using `happy log <YOUR_ENTRY>`.  
-For more info use `happy log -h`"""
+                "To initialise your happyjar, log an entry using `happy log <YOUR_ENTRY>`."
             ),
+            "",
+            Markdown("For more info use `happy log -h`"),
             "",
             style="error",
         )

--- a/happy/main.py
+++ b/happy/main.py
@@ -16,11 +16,15 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.theme import Theme
 
-custom_theme = Theme({"info": "bold color(39)",
-"error": "bold red",
-"date": "color(111)",
-"entry": "bold italic default",
-"warning": "italic dim yellow"})
+custom_theme = Theme(
+    {
+        "info": "bold color(39)",
+        "error": "bold red",
+        "date": "color(111)",
+        "entry": "bold default",
+        "warning": "italic dim yellow",
+    }
+)
 
 HOME = expanduser("~")
 
@@ -50,22 +54,39 @@ def write_file(payload, time=None):
         except Exception as err:
             console.print(f"Error occurred: {err}", style="error")
         else:
-            console.print("",
-                Markdown("""Jar created!  
+            console.print(
+                "",
+                Markdown(
+                    """Jar created!  
 Entry written successfully!  
 Use `happy get all` or `happy get today` to view your logs!  
-"""), "", style="info")
+"""
+                ),
+                "",
+                style="info",
+            )
 
 
 def read_file(
-    date=False, today=False, flowers=False, after=False, before=False, random=0, nocolor=False
+    date=False,
+    today=False,
+    flowers=False,
+    after=False,
+    before=False,
+    random=0,
+    nocolor=False,
 ):
     display = False
     if not exists(f"{HOME}/.happyjar.txt"):
         console.print(
-            Markdown("""Error: your happyjar has not been initialised yet.  
+            Markdown(
+                """Error: your happyjar has not been initialised yet.  
 To initialise your happyjar, log an entry using `happy log <YOUR_ENTRY>`.  
-For more info use `happy log -h`"""), "", style="error")
+For more info use `happy log -h`"""
+            ),
+            "",
+            style="error",
+        )
         exit()
 
     if today:
@@ -86,7 +107,9 @@ For more info use `happy log -h`"""), "", style="error")
         try:  # convert user inputted string to dt object
             converted_dt = datetime.strptime(date, "%d/%m/%Y")
         except ValueError:
-            console.print("Error occurred converting date to date object", style="error")
+            console.print(
+                "Error occurred converting date to date object", style="error"
+            )
             exit()
         else:
             try:
@@ -141,24 +164,28 @@ def display_entry(flowers, line, nocolor):
     date = line[0]
     entry = line[1]
 
-    toggle_style = ["date","entry"]
+    toggle_style = ["date", "entry"]
     if nocolor:
-        toggle_style = ["default","default"]
-           
+        toggle_style = ["default", "default"]
+
     flower = ""
     flower_selection = ["🌼 ", "🍀 ", "🌻 ", "🌺 ", "🌹 ", "🌸 ", "🌷 ", "💐 ", "🏵️  "]
-    
+
     if line != "\n" and flowers:
         flower = choice(flower_selection)
-        
-        console.print(f"{flower} [{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]")
+
+        console.print(
+            f"{flower} [{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]"
+        )
     else:
-        console.print(f"[{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]")
+        console.print(
+            f"[{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]"
+        )
 
 
 def cli() -> None:
     description = "Log your good memories and gratitiude."
-    epilog = "examples:\nhappy log \"i am so happy because you starred this project's repo on github xDD\"\n`happy get all`\n\nFor more help use `happy log --help` and `happy get --help`"
+    epilog = 'examples:\nhappy log "i am so happy because you starred this project\'s repo on github xDD"\n`happy get all`\n\nFor more help use `happy log --help` and `happy get --help`'
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=description,
@@ -186,7 +213,11 @@ def cli() -> None:
     get.add_argument(
         "--flowers", help="adds a random flower to your entry 🌼", action="store_true"
     )
-    get.add_argument("--nocolor", help="displays entries without any color formatting", action="store_true")
+    get.add_argument(
+        "--nocolor",
+        help="displays entries without any color formatting",
+        action="store_true",
+    )
 
     args = parser.parse_args(argv[1:])
 
@@ -194,39 +225,40 @@ def cli() -> None:
         write_file(args.log_entry)
         exit()
     if args.command == "get":
-        def bottom_rule():
-            console.rule()
+
+        def header(msg=""):
+            console.rule(f"[bold]{msg}", style="bold color(105)", align="left")
             console.print("")
-            
+
+        footer = header
+
         # `happy get today`
         if args.all == "today":
             console.print("")
-            console.rule("Today's Entries")
-            console.print("")
+            header("Today's Entries")
             read_file(today=True, flowers=args.flowers, nocolor=args.nocolor)
-            bottom_rule()
+            footer()
             exit()
 
         # `happy get all`
         elif args.all == "all":
             console.print("")
-            console.rule("All Entries")
-            console.print("")
+            header("All Entries")
             read_file(flowers=args.flowers, nocolor=args.nocolor)
-            bottom_rule()
+            footer()
 
         # `happy get random [<num>]`
         elif args.all == "random":
             console.print("")
             if args.today:
-                console.rule("Random Entries")
-                console.print("")
-                read_file(random=int(args.today), flowers=args.flowers, nocolor=args.nocolor)
+                header("Random Entries")
+                read_file(
+                    random=int(args.today), flowers=args.flowers, nocolor=args.nocolor
+                )
             else:
-                console.rule("Random Entry")
-                console.print("")
+                header("Random Entry")
                 read_file(random=1, flowers=args.flowers, nocolor=args.nocolor)
-            bottom_rule()
+            footer()
 
         # `happy get [after|before|<date>]
         else:
@@ -250,19 +282,24 @@ def cli() -> None:
             else:
                 if dt:
                     if args.all == "before" or args.all == "after":
-                        console.rule(f"Entries logged {args.all} {dt.group()}")
+                        header(f"Entries logged {args.all} {dt.group()}")
                     else:
-                        console.rule(f"Entries logged on {dt.group()}")
-                    console.print("")
+                        header(f"Entries logged on {dt.group()}")
                     read_file(
                         date=dt.group(),
                         flowers=args.flowers,
                         after=args.all == "after",
-                        before=args.all == "before", nocolor=args.nocolor
+                        before=args.all == "before",
+                        nocolor=args.nocolor,
                     )
-                    bottom_rule()
+                    footer()
                 else:
-                    console.print(Markdown("Error: please enter the date as the format `dd/mm/yyyy`"), style="error")
+                    console.print(
+                        Markdown(
+                            "Error: please enter the date as the format `dd/mm/yyyy`"
+                        ),
+                        style="error",
+                    )
 
             exit()
 

--- a/happy/main.py
+++ b/happy/main.py
@@ -207,6 +207,10 @@ def display_entry(flowers, line, nocolor):
         console.print(
             f"{flower} [{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]"
         )
+    else:
+        console.print(
+            f"[{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]"
+        )
 
 
 def cli() -> None:

--- a/happy/main.py
+++ b/happy/main.py
@@ -16,10 +16,10 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.theme import Theme
 
-custom_theme = Theme({"info": "bold cyan",
+custom_theme = Theme({"info": "bold color(112)",
 "error": "bold red",
-"date": "bold blue",
-"entry": "bold italic yellow",
+"date": "color(111)",
+"entry": "bold italic default",
 "warning": "italic dim yellow"})
 
 HOME = expanduser("~")
@@ -42,7 +42,7 @@ def write_file(payload, time=None):
         except Exception as err:
             console.print(f"Error occurred: {err}", style="error")
         else:
-            console.print("Entry written successfully!", style="info")
+            console.print("\nEntry written successfully!\n", style="info")
     else:
         try:
             with open(f"{HOME}/.happyjar.txt", "w") as happy_file:
@@ -53,7 +53,8 @@ def write_file(payload, time=None):
             console.print(
                 Markdown("""Jar created!  
 Entry written successfully!  
-Use `happy get all` or `happy get today` to view your logs!"""), style="info")
+Use `happy get all` or `happy get today` to view your logs!  
+"""), "", style="info")
 
 
 def read_file(
@@ -64,8 +65,7 @@ def read_file(
         console.print(
             Markdown("""Error: your happyjar has not been initialised yet.  
 To initialise your happyjar, log an entry using `happy log <YOUR_ENTRY>`.  
-For more info use `happy log -h`\n"""), style="error"
-        )
+For more info use `happy log -h`"""), "", style="error")
         exit()
 
     if today:
@@ -137,13 +137,24 @@ For more info use `happy log -h`\n"""), style="error"
 
 def display_entry(flowers, line):
     """displays entries with or without flowers or colors"""
+    line = line.split(": ")
+    date = line[0]
+    entry = line[1]
+    toggle_style = ["date","entry"]
+    
+#    if nocolor:
+#        toggle_style = [None,None]
+
+    
     flower = ""
     flower_selection = ["🌼 ", "🍀 ", "🌻 ", "🌺 ", "🌹 ", "🌸 ", "🌷 ", "💐 ", "🏵️  "]
+    
     if line != "\n" and flowers:
         flower = choice(flower_selection)
+        
         console.print(f"{flower}{line}")
     else:
-        console.print(line)
+        console.print(f"[{toggle_style[0]}][{date}][/{toggle_style[0]}]: [{toggle_style[1]}]{entry}[/{toggle_style[1]}]")
 
 
 def cli() -> None:
@@ -221,7 +232,7 @@ def cli() -> None:
             except TypeError:
                 # this triggers the command
                 # `happy get` without any other args
-                console.print(Markdown("Please use an argument after `get`"), style="warning")
+                console.print("Please use an argument after `get`\n", style="warning")
                 get.print_help()  # print usage for `get`
             else:
                 if dt:

--- a/happy/main.py
+++ b/happy/main.py
@@ -21,7 +21,7 @@ custom_theme = Theme(
         "info": "bold color(39)",
         "error": "bold red",
         "date": "color(111)",
-        "entry": "bold default",
+        "entry": "default",
         "warning": "italic dim yellow",
     }
 )
@@ -177,11 +177,6 @@ def read_file(
 
 
 def display_entry(flowers, line, nocolor):
-    """displays entries with or without flowers or colors"""
-
-
-
-def display_entry(flowers, line, nocolor):
     """
     displays entries with or without flowers
     ---
@@ -285,17 +280,19 @@ def cli() -> None:
             console.print("")
             if args.today:
                 try:
-                  header("Random Entries")
-                  read_file(
-                      random=int(args.today), flowers=args.flowers, nocolor=args.nocolor
+                    random_num = int(args.today)
+                    header("Random Entries")
+                    read_file(
+                        random=random_num, flowers=args.flowers, nocolor=args.nocolor
                   )
                 except ValueError:  # a valid number wasn't provided
-                  console.print(
+                    console.print(
                         Markdown(
-                            "Error: please enter a valid number after `random` or `random` on it's own\n"
+                            "Error: please enter a valid number after `random` or `random` on it's own"
                         ),
                         style="error",)
-                  exit()
+                    print("")
+                    exit()
             else:
                 header("Random Entry")
                 read_file(random=1, flowers=args.flowers, nocolor=args.nocolor)

--- a/happy/main.py
+++ b/happy/main.py
@@ -13,10 +13,18 @@ import argparse
 import textwrap
 import re
 from rich.console import Console
+from rich.markdown import Markdown
+from rich.theme import Theme
+
+custom_theme = Theme({"info": "bold cyan",
+"error": "bold red",
+"date": "bold blue",
+"entry": "bold italic yellow",
+"warning": "italic dim yellow"})
 
 HOME = expanduser("~")
 
-console = Console(highlight=False)
+console = Console(highlight=False, theme=custom_theme)
 
 
 def write_file(payload, time=None):
@@ -32,19 +40,20 @@ def write_file(payload, time=None):
             with open(f"{HOME}/.happyjar.txt", "a") as happy_file:
                 happy_file.write(f"{time}: {payload}\n")
         except Exception as err:
-            console.print(f"Error occurred: {err}")
+            console.print(f"Error occurred: {err}", style="error")
         else:
-            console.print("Entry written successfully!")
+            console.print("Entry written successfully!", style="info")
     else:
         try:
             with open(f"{HOME}/.happyjar.txt", "w") as happy_file:
                 happy_file.write(f"{time}: {payload}\n")
         except Exception as err:
-            console.print(f"Error occurred: {err}")
+            console.print(f"Error occurred: {err}", style="error")
         else:
             console.print(
-                "\nJar created!\nEntry written successfully!\nUse 'happy get all' or 'happy get today' to view your logs!"
-            )
+                Markdown("""Jar created!  
+Entry written successfully!  
+Use `happy get all` or `happy get today` to view your logs!"""), style="info")
 
 
 def read_file(
@@ -53,7 +62,9 @@ def read_file(
     display = False
     if not exists(f"{HOME}/.happyjar.txt"):
         console.print(
-            "Error: your happyjar has not been initialised yet. To do that, log an entry using 'happy log \"my first log\"'.\nFor more info use 'happy log -h'\n"
+            Markdown("""Error: your happyjar has not been initialised yet.  
+To initialise your happyjar, log an entry using `happy log <YOUR_ENTRY>`.  
+For more info use `happy log -h`\n"""), style="error"
         )
         exit()
 
@@ -75,7 +86,7 @@ def read_file(
         try:  # convert user inputted string to dt object
             converted_dt = datetime.strptime(date, "%d/%m/%Y")
         except ValueError:
-            console.print("Error occurred converting date to date object")
+            console.print("Error occurred converting date to date object", style="error")
             exit()
         else:
             try:
@@ -121,11 +132,11 @@ def read_file(
                 display = True
                 display_entry(flowers, line)
     if not display:
-        print("No entries for selected time period")
+        console.print("No entries for selected time period", style="info")
 
 
 def display_entry(flowers, line):
-    """displays entries with or without flowers"""
+    """displays entries with or without flowers or colors"""
     flower = ""
     flower_selection = ["🌼 ", "🍀 ", "🌻 ", "🌺 ", "🌹 ", "🌸 ", "🌷 ", "💐 ", "🏵️  "]
     if line != "\n" and flowers:
@@ -137,7 +148,7 @@ def display_entry(flowers, line):
 
 def cli() -> None:
     description = "Log your good memories and gratitiude."
-    epilog = "examples:\nhappy log \"i am so happy because you starred this project's repo on github xDD\"\n'happy get all'\n\nFor more help use 'happy log --help' and 'happy get --help'"
+    epilog = "examples:\nhappy log \"i am so happy because you starred this project's repo on github xDD\"\n`happy get all`\n\nFor more help use `happy log --help` and `happy get --help`"
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=description,
@@ -165,6 +176,7 @@ def cli() -> None:
     get.add_argument(
         "--flowers", help="adds a random flower to your entry 🌼", action="store_true"
     )
+    #get.add_argument("--nocolor", help="displays entries without any color formatting", action="store_true")
 
     args = parser.parse_args(argv[1:])
 
@@ -209,7 +221,7 @@ def cli() -> None:
             except TypeError:
                 # this triggers the command
                 # `happy get` without any other args
-                console.print("Please use an argument after `get`\n")
+                console.print(Markdown("Please use an argument after `get`"), style="warning")
                 get.print_help()  # print usage for `get`
             else:
                 if dt:
@@ -220,7 +232,7 @@ def cli() -> None:
                         before=args.all == "before",
                     )
                 else:
-                    print("Error: please enter the date as the format dd/mm/yyyy")
+                    console.print(Markdown("Error: please enter the date as the format `dd/mm/yyyy`"), style="error")
 
             exit()
 

--- a/happy/main.py
+++ b/happy/main.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.theme import Theme
 
-custom_theme = Theme({"info": "bold color(112)",
+custom_theme = Theme({"info": "bold color(39)",
 "error": "bold red",
 "date": "color(111)",
 "entry": "bold italic default",
@@ -50,7 +50,7 @@ def write_file(payload, time=None):
         except Exception as err:
             console.print(f"Error occurred: {err}", style="error")
         else:
-            console.print(
+            console.print("",
                 Markdown("""Jar created!  
 Entry written successfully!  
 Use `happy get all` or `happy get today` to view your logs!  
@@ -194,25 +194,39 @@ def cli() -> None:
         write_file(args.log_entry)
         exit()
     if args.command == "get":
-        
+        def bottom_rule():
+            console.rule()
+            console.print("")
+            
         # `happy get today`
         if args.all == "today":
             console.print("")
+            console.rule("Today's Entries")
+            console.print("")
             read_file(today=True, flowers=args.flowers, nocolor=args.nocolor)
+            bottom_rule()
             exit()
 
         # `happy get all`
         elif args.all == "all":
             console.print("")
+            console.rule("All Entries")
+            console.print("")
             read_file(flowers=args.flowers, nocolor=args.nocolor)
+            bottom_rule()
 
         # `happy get random [<num>]`
         elif args.all == "random":
             console.print("")
             if args.today:
+                console.rule("Random Entries")
+                console.print("")
                 read_file(random=int(args.today), flowers=args.flowers, nocolor=args.nocolor)
             else:
+                console.rule("Random Entry")
+                console.print("")
                 read_file(random=1, flowers=args.flowers, nocolor=args.nocolor)
+            bottom_rule()
 
         # `happy get [after|before|<date>]
         else:
@@ -235,12 +249,18 @@ def cli() -> None:
                 get.print_help()  # print usage for `get`
             else:
                 if dt:
+                    if args.all == "before" or args.all == "after":
+                        console.rule(f"Entries logged {args.all} {dt.group()}")
+                    else:
+                        console.rule(f"Entries logged on {dt.group()}")
+                    console.print("")
                     read_file(
                         date=dt.group(),
                         flowers=args.flowers,
                         after=args.all == "after",
                         before=args.all == "before", nocolor=args.nocolor
                     )
+                    bottom_rule()
                 else:
                     console.print(Markdown("Error: please enter the date as the format `dd/mm/yyyy`"), style="error")
 


### PR DESCRIPTION
Same as my previous PR but using Textualize/rich, 
This new PR has more additions than the last, I used `rich.markdown` for highlighting commands, used `rich.theme` to make it easier to modify color styles later, and I added a header and footer format when displaying entries.
Also I added a `--nocolor` option which returns all color and style settings to default when displaying entries, as per your request.

Please feel free to make changes to this after merging, especially with the color choices, you can change them to whatever you think seems right, the current setting looks good on both light and dark terminals.

Fix #13  