### PR TITLE
Fixed permission needs inside workflow.

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+    
+permissions:
+  contents: read
 
 jobs:
   deploy:


### PR DESCRIPTION
This issue adds a new `permissions` field to the workflow YAML file, which in turn enables the PyPI release workflow to read the contents of the repository, especially the **dist** folder after building.