### PR TITLE
Fixed duplicate job inside workflow.

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -38,13 +38,6 @@ jobs:
         overwrite: true
         file_glob: true
 
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install build
-    - name: Build package
-      run: python -m build
-
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:


### PR DESCRIPTION
This PR fixes a duplicate job for setting up dependencies within the `.github/workflows/pypi-release.yml` GitHub Actions workflow file.