### PR TITLE
🐛 FIX: emoji (with space after) displaying issue

### DIFF
--- a/happy/main.py
+++ b/happy/main.py
@@ -223,7 +223,7 @@ def display_entry(flowers, line, nocolor, count=False, tags=False):
         # format the output
         line = line.split(": ")
         date = line[0]
-        entry = line[1]
+        entry = ": ".join(line[1:])  # reconstruct any split emojis
         toggle_style = ["date", "entry"]
     if nocolor:
         toggle_style = ["default", "default"]


### PR DESCRIPTION
Fixes: #38 

The exact issue was that the splitting of the line to extract the date also split the line at any emoji with a space afterwards, so this bug was easily observed in tagged entries ending with an emoji (since the tag was appended right after the ending emoji with a space in between)

Screenshots:
![image](https://user-images.githubusercontent.com/68962290/197395785-ba2be67a-5670-430d-9676-02b83f15575d.png)
![image](https://user-images.githubusercontent.com/68962290/197395804-588c890a-7c74-41c2-920e-00f47e98e9f3.png)
